### PR TITLE
Supporting changing database name & byte[] type

### DIFF
--- a/litepal/src/main/java/org/litepal/crud/DataHandler.java
+++ b/litepal/src/main/java/org/litepal/crud/DataHandler.java
@@ -686,6 +686,11 @@ abstract class DataHandler extends LitePalBase {
 			String columnName = isIdColumn(field.getName()) ? "id" : field.getName();
 			int columnIndex = cursor.getColumnIndex(BaseUtility.changeCase(columnName));
 			if (columnIndex != -1) {
+        if (field.getType() == byte[].class || field.getType() == Byte[].class) {
+					putSetMethodValueByField((DataSupport) modelInstance, field, cursor.getBlob(columnIndex));
+          continue;
+        }
+
 				Class<?> cursorClass = cursor.getClass();
 				Method method = cursorClass.getMethod(getMethodName, int.class);
 				Object value = method.invoke(cursor, columnIndex);

--- a/litepal/src/main/java/org/litepal/crud/DataSupport.java
+++ b/litepal/src/main/java/org/litepal/crud/DataSupport.java
@@ -1354,4 +1354,15 @@ public class DataSupport {
 		getListToClearAssociatedFK().clear();
 	}
 
+  public static void execSQL(String sql) {
+    execSQL(sql, null);
+  }
+
+  public static void execSQL(String sql, Object[] bindArgs) {
+    try {
+      Connector.getDatabase().execSQL(sql, bindArgs);
+    } catch(android.database.SQLException e) {
+      e.printStackTrace();
+    }
+  }
 }

--- a/litepal/src/main/java/org/litepal/tablemanager/DatabaseEventListener.java
+++ b/litepal/src/main/java/org/litepal/tablemanager/DatabaseEventListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C)  Tony Green, Litepal Framework Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.litepal.tablemanager;
+
+import android.database.sqlite.SQLiteDatabase;
+
+/**
+ * @author neevek <i@neevek.net>
+ */
+public interface DatabaseEventListener {
+  String getDBNamePrefix();
+  void onCreate(SQLiteDatabase db);
+  void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion);
+}

--- a/litepal/src/main/java/org/litepal/tablemanager/LitePalOpenHelper.java
+++ b/litepal/src/main/java/org/litepal/tablemanager/LitePalOpenHelper.java
@@ -17,6 +17,7 @@
 package org.litepal.tablemanager;
 
 import org.litepal.LitePalApplication;
+import org.litepal.tablemanager.DatabaseEventListener;
 import org.litepal.util.SharedUtil;
 
 import android.content.Context;
@@ -40,6 +41,8 @@ import android.database.sqlite.SQLiteOpenHelper;
 class LitePalOpenHelper extends SQLiteOpenHelper {
 	public static final String TAG = "LitePalHelper";
 
+  private DatabaseEventListener listener;
+
 	/**
 	 * The standard constructor for SQLiteOpenHelper.
 	 * 
@@ -57,8 +60,9 @@ class LitePalOpenHelper extends SQLiteOpenHelper {
 	 *            onDowngrade(SQLiteDatabase, int, int) will be used to
 	 *            downgrade the database
 	 */
-	LitePalOpenHelper(Context context, String name, CursorFactory factory, int version) {
+	LitePalOpenHelper(Context context, String name, CursorFactory factory, int version, DatabaseEventListener listener) {
 		super(context, name, factory, version);
+    this.listener = listener;
 	}
 
 	/**
@@ -75,19 +79,24 @@ class LitePalOpenHelper extends SQLiteOpenHelper {
 	 *            onDowngrade(SQLiteDatabase, int, int) will be used to
 	 *            downgrade the database
 	 */
-	LitePalOpenHelper(String dbName, int version) {
-		this(LitePalApplication.getContext(), dbName, null, version);
+	LitePalOpenHelper(String dbName, int version, DatabaseEventListener listener) {
+		this(LitePalApplication.getContext(), dbName, null, version, listener);
 	}
 
 	@Override
 	public void onCreate(SQLiteDatabase db) {
 		Generator.create(db);
+    if (listener != null) {
+      listener.onCreate(db);
+    }
 	}
 
 	@Override
 	public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 		Generator.upgrade(db);
 		SharedUtil.updateVersion(newVersion);
+    if (listener != null) {
+      listener.onUpgrade(db, oldVersion, newVersion);
+    }
 	}
-
 }

--- a/litepal/src/main/java/org/litepal/tablemanager/typechange/BooleanOrm.java
+++ b/litepal/src/main/java/org/litepal/tablemanager/typechange/BooleanOrm.java
@@ -37,6 +37,10 @@ public class BooleanOrm extends OrmChange {
 				String[] relations = { columnName, "INTEGER" };
 				return relations;
 			}
+			if (fieldType.equals("[B") || fieldType.equals("[Ljava.lang.Byte;")) {
+				String[] relations = { columnName, "BLOB" };
+				return relations;
+			}
 		}
 		return null;
 	}

--- a/litepal/src/main/java/org/litepal/util/BaseUtility.java
+++ b/litepal/src/main/java/org/litepal/util/BaseUtility.java
@@ -163,7 +163,19 @@ public class BaseUtility {
 	 * @return Supported return true, not supported return false.
 	 */
 	public static boolean isFieldTypeSupported(String fieldType) {
+		if ("int".equals(fieldType) || "java.lang.Integer".equals(fieldType)) {
+			return true;
+		}
+		if ("java.lang.String".equals(fieldType) || "java.util.Date".equals(fieldType)) {
+			return true;
+		}
+		if ("long".equals(fieldType) || "java.lang.Long".equals(fieldType)) {
+			return true;
+		}
 		if ("boolean".equals(fieldType) || "java.lang.Boolean".equals(fieldType)) {
+			return true;
+		}
+		if ("[B".equals(fieldType) || "[Ljava.lang.Byte;".equals(fieldType)) {
 			return true;
 		}
 		if ("float".equals(fieldType) || "java.lang.Float".equals(fieldType)) {
@@ -172,19 +184,10 @@ public class BaseUtility {
 		if ("double".equals(fieldType) || "java.lang.Double".equals(fieldType)) {
 			return true;
 		}
-		if ("int".equals(fieldType) || "java.lang.Integer".equals(fieldType)) {
-			return true;
-		}
-		if ("long".equals(fieldType) || "java.lang.Long".equals(fieldType)) {
-			return true;
-		}
 		if ("short".equals(fieldType) || "java.lang.Short".equals(fieldType)) {
 			return true;
 		}
 		if ("char".equals(fieldType) || "java.lang.Character".equals(fieldType)) {
-			return true;
-		}
-		if ("java.lang.String".equals(fieldType) || "java.util.Date".equals(fieldType)) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
1. Added    `DatabaseEventListener` to listen for `onCreate()` and `onUpgrade()` events, also offers a `getDBNamePrefix()` method from the listener for LitePal to get a prefix to be prepended to the dbname defined in `assets/litepal.xml` file.
2. Added `Connector.closeDatabase()` so database can be closed and re-initialized with a different name at runtime.
3. Added support for byte[] type, i.e. the `blob` type in SQLite.
