### PR TITLE
多线程初始化获取的时候一个BUG

### DIFF
--- a/core/src/main/java/org/litepal/parser/LitePalAttr.java
+++ b/core/src/main/java/org/litepal/parser/LitePalAttr.java
@@ -86,15 +86,16 @@ public final class LitePalAttr {
 		if (litePalAttr == null) {
 			synchronized (LitePalAttr.class) {
 				if (litePalAttr == null) {
-					litePalAttr = new LitePalAttr();
-                    loadLitePalXMLConfiguration();
+					LitePalAttr litePalAttrTemp = new LitePalAttr();
+					loadLitePalXMLConfiguration(litePalAttrTemp);
+					litePalAttr = litePalAttrTemp;
 				}
 			}
 		}
 		return litePalAttr;
 	}
 
-	private static void loadLitePalXMLConfiguration() {
+	private static void loadLitePalXMLConfiguration(LitePalAttr litePalAttr) {
         if (BaseUtility.isLitePalXMLExists()) {
             LitePalConfig config = LitePalParser.parseLitePalConfiguration();
             litePalAttr.setDbName(config.getDbName());
@@ -192,7 +193,7 @@ public final class LitePalAttr {
 	 */
 	public void checkSelfValid() {
 		if (TextUtils.isEmpty(dbName)) {
-            loadLitePalXMLConfiguration();
+			loadLitePalXMLConfiguration(this);
             if (TextUtils.isEmpty(dbName)) {
                 throw new InvalidAttributesException(
                         InvalidAttributesException.DBNAME_IS_EMPTY_OR_NOT_DEFINED);


### PR DESCRIPTION
多线程初始化获取的时候 checkSelfValid 方法调用 loadLitePalXMLConfiguration 会覆盖(dbName增加 .dp 后缀) 的值